### PR TITLE
Annotate input properties

### DIFF
--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateLexer.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateLexer.groovy
@@ -1,11 +1,14 @@
 package org.jetbrains.grammarkit.tasks
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class GenerateLexer extends BaseTask {
 
-    def targetDir
-    def targetClass
-    def source
-    def skeleton
+    @Input def targetDir
+    @Input def targetClass
+    @Input def source
+    @Input @Optional def skeleton
 
     GenerateLexer() {
         project.afterEvaluate({

--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
@@ -1,11 +1,14 @@
 package org.jetbrains.grammarkit.tasks
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class GenerateParser extends BaseTask {
-    def source
-    def targetRoot
+    @Input def source
+    @Input @Optional def targetRoot
     // would be nice to obtain these from the GC
-    def pathToParser
-    def pathToPsiRoot
+    @Input def pathToParser
+    @Input def pathToPsiRoot
 
     GenerateParser() {
         setMain("org.intellij.grammar.Main");


### PR DESCRIPTION
Hi!

Now the plugin will print something like

```
* What went wrong:
A problem was found with the configuration of task ':generateRustDocHighlightingLexer'.
> No value has been specified for property 'targetClass'.
```

if the user forgets to specify the property, instead of silently specifying wrong task outputs. 